### PR TITLE
Corregir url a foftw en polandpriv

### DIFF
--- a/polandpriv.html
+++ b/polandpriv.html
@@ -74,12 +74,11 @@
               <a href="https://freekibyte.github.io/freekibyte/hardw.html"><button><b>HARDW</b></button></a>
             </td>
             <td>
-              <a href="https://freekibyte.github.io/freekibyte/soft.html">
-                <button><b>SOFTW</b></button>
-              </a>
+              <a href="https://freekibyte.github.io/freekibyte/softw.html"><button><b>SOFTW</b></button></a>
             </td>
             <td>
               <a href="https://freekibyte.github.io/freekibyte/free.html"><button><b>FREE</b></button></a>
+            </td>
             <td>
               <a href="https://freekibyte.github.io/freekibyte/apps.html"><button><b>APPs</b></button></a>
             </td>


### PR DESCRIPTION
Corregida la URL de enlace, al documento HTML "softw", desde el documento HTML "polandpriv".